### PR TITLE
Change TF artifacts-admin bucket name

### DIFF
--- a/tce.rb
+++ b/tce.rb
@@ -121,7 +121,7 @@ TANZU_CLI_NO_INIT=true tanzu init
 
 # TCE_REPO="$(tanzu plugin repo list | grep core-admin)"
 # if [[ -z "${TCE_REPO}"  ]]; then
-#   tanzu plugin repo add --name core-admin --gcp-bucket-name tce-tanzu-cli-admin-plugins --gcp-root-path artifacts-admin
+#   tanzu plugin repo add --name core-admin --gcp-bucket-name tce-tanzu-cli-framework-admin --gcp-root-path artifacts-admin
 # fi
 
 echo "Installation complete!"


### PR DESCRIPTION
This changes the bucket name from `tce-tanzu-cli-admin-plugins`  to `tce-tanzu-cli-framework-admin` because the admin plugins are TF owned/generated plugins and not TCE originated... the bucket name seems to suggest otherwise.