### PR TITLE
Formula Update #8

### DIFF
--- a/tanzu-community-edition.rb
+++ b/tanzu-community-edition.rb
@@ -15,8 +15,6 @@ class TanzuCommunityEdition < Formula
     sha256 "9558eb0f364c841dd293aacba1c28747cd17f773ad259c0853d1c25c104ad22e"
   end
 
-  depends_on :arch => :x86_64
-
   def install
     bin.install "bin/tanzu"
     libexec.install Dir["bin/tanzu-plugin-*"]


### PR DESCRIPTION
- Use dashes instead of underscores in formula name. #8
- Remove the depends_on for amd64

Signed-off-by: Nicholas Seemiller <nseemiller@vmware.com>