### PR TITLE
Update CONTRIB docs to state need for CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,7 @@
 # Homebrew-Tanzu
 
 The homebrew-tanzu project team welcomes contributions from the community. Before you start working with homebrew-tanzu, please
-read our [Developer Certificate of Origin](https://cla.vmware.com/dco). All contributions to this repository must be
-signed as described on that page. Your signature certifies that you wrote the patch or have the right to pass it on
-as an open-source patch.
+complete a [Contributor License Agreement](#contributor-license-agreement).
 
 ## Contribution workflow
 
@@ -73,4 +71,3 @@ Note: if you would like to submit an "_obvious fix_" for something like a typo,
 formatting issue or spelling mistake, you may not need to sign the CLA.
 
 [new-issue]: https://github.com/vmware-tanzu/homebrew-tanzu/issues/new/
-


### PR DESCRIPTION
We were originally hoping to go with the DCO for contributions, but
needed to switch to the CLA. This updates our CONTRIBUTING.md
documentation to drop references to using the DCO and add information on
how to sign the VMware CLA.