### PR TITLE
Use a single install command #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Homebrew tap for [Tanzu Community Edition](https://github.com/vmware-tanzu/commu
 Usage
 
 ```shell
-brew tap vmware-tanzu/tanzu
-brew install tanzu-community-edition
+brew install vmware-tanzu/tanzu/tanzu-community-edition
 ```
 
 > Be sure to run the `configure-tce.sh` script referenced in the post-install steps.


### PR DESCRIPTION
Homebrew can tap and install with a single command instead of separate `tap` and `install` commands.

Let's use that that simplify the install process.

Fixes #12 