### PR TITLE
Add workflow config and script to check homebrew formula changes in PRs

### DIFF
--- a/.github/workflows/check-tce-homebrew-formula-pr.yaml
+++ b/.github/workflows/check-tce-homebrew-formula-pr.yaml
@@ -1,0 +1,25 @@
+name: Check - TCE Homebrew Formula
+
+on:
+  pull_request:
+    types:
+      - assigned
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "tanzu-community-edition.rb"
+      - ".github/workflows/check-tce-homebrew-formula-pr.yaml"
+
+jobs:
+  check-tce-homebrew-formula:
+    name: Check - TCE Homebrew Formula
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Check - TCE Homebrew Formula
+        shell: bash
+        run: |
+          ./test/check-tce-homebrew-formula.sh

--- a/test/check-tce-homebrew-formula.sh
+++ b/test/check-tce-homebrew-formula.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HOMEBREW_TAP_REPO_PATH="${MY_DIR}"/..
+
+HOMEBREW_DIR="$(mktemp -d)"
+
+trap '{ rm -rf -- "${HOMEBREW_DIR}"; }' EXIT
+
+curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C "${HOMEBREW_DIR}"
+
+shellenv=$("${HOMEBREW_DIR}"/bin/brew shellenv)
+
+eval "${shellenv}"
+
+brew update --force --quiet
+
+brew install --formula "${HOMEBREW_TAP_REPO_PATH}"/tanzu-community-edition.rb
+
+tce_installation_dir=("${HOMEBREW_DIR}"/Cellar/tanzu-community-edition/*)
+
+if [ ${#tce_installation_dir[@]} != 1 ]; then
+    echo "TCE was not installed!"
+    exit 1
+fi
+
+"${tce_installation_dir[0]}"/libexec/configure-tce.sh
+
+tanzu version
+
+tanzu cluster version
+
+tanzu conformance version
+
+tanzu diagnostics version
+
+tanzu kubernetes-release version
+
+tanzu management-cluster version
+
+tanzu package version
+
+tanzu standalone-cluster version
+
+tanzu pinniped-auth version
+
+tanzu builder version
+
+tanzu login version
+
+"${tce_installation_dir[0]}"/libexec/uninstall.sh
+
+set +o xtrace
+source ~/.bash_profile
+set -o xtrace
+
+if [[ -n "$(command -v tanzu)" ]]; then
+    echo "tanzu command still exists!"
+    exit 1
+fi


### PR DESCRIPTION
## What this PR does / why we need it

Adds workflow config and script to check homebrew formula changes in PRs

## Which issue(s) this PR fixes

Fixes: #20 

## Describe testing done for PR

See the automated check happening here - https://github.com/karuppiah7890/homebrew-tanzu/pull/5/checks

## Special notes for your reviewer

This change only runs tests for PRs. It doesn't run any test in `main` as mentioned in #20 . I was thinking that maybe we don't need to test `brew install vmware-tanzu/tanzu/tanzu-community-edition` assuming that `brew` can do it's job well in terms of pulling the Homebrew tap repo and installing TCE from the TCE Homebrew formula. Let me know if still want to have a separate test that runs in `main` which does `brew install vmware-tanzu/tanzu/tanzu-community-edition`
