### PR TITLE
Update TCE installer bash script in brew install to replicate TCE repo install bash script

### DIFF
--- a/tanzu-community-edition.rb
+++ b/tanzu-community-edition.rb
@@ -4,15 +4,15 @@
 class TanzuCommunityEdition < Formula
   desc "Tanzu Community Edition"
   homepage "https://github.com/vmware-tanzu/community-edition"
-  version "v0.11.0"
+  version "v0.12.0"
   head "https://github.com/vmware-tanzu/community-edition.git"
 
   if OS.mac?
     url "https://github.com/vmware-tanzu/community-edition/releases/download/#{version}/tce-darwin-amd64-#{version}.tar.gz"
-    sha256 "c1bd55cca7b618af695447d4808d3b7fac7f33592c83f2dc3c789e1e2ece57e1"
+    sha256 "4640f41b773087068e50ddce1455bc0b6b74300b2884557ab70ae2f2cc44a9de"
   elsif OS.linux?
     url "https://github.com/vmware-tanzu/community-edition/releases/download/#{version}/tce-linux-amd64-#{version}.tar.gz"
-    sha256 "c287e86caf995b8d84068902635be1e3ded9b8be7889b69b302da27e543ace1e"
+    sha256 "32c8047c1e82691f17541159571f8216ee97423efeddb9a396b1addbfb06f37f"
   end
 
   def install
@@ -58,9 +58,9 @@ class TanzuCommunityEdition < Formula
 
   def brew_installer_script
     <<-EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# Copyright 2021-22 VMware Tanzu Community Edition contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -o errexit
@@ -110,19 +110,9 @@ install "${MY_DIR}/uninstall.sh" "${XDG_DATA_HOME}/tce"
 mkdir -p "${XDG_CONFIG_HOME}/tanzu-plugins"
 
 cp -r "${MY_DIR}/default-local/." "${XDG_CONFIG_HOME}/tanzu-plugins"
-# install plugins
-tanzu plugin install builder
-tanzu plugin install codegen
-tanzu plugin install cluster
-tanzu plugin install kubernetes-release
-tanzu plugin install login
-tanzu plugin install management-cluster
-tanzu plugin install package
-tanzu plugin install pinniped-auth
-tanzu plugin install secret
-tanzu plugin install conformance
-tanzu plugin install diagnostics
-tanzu plugin install unmanaged-cluster
+
+# explicit init of tanzu cli and add tce repo
+tanzu init
 
 # Make a backup of Kubernetes configs
 set +o errexit


### PR DESCRIPTION
## What this PR does / why we need it

Update TCE installer bash script in brew install to replicate TCE repo install bash script by running `tanzu init` instead of individual CLI plugin installs

## Which issue(s) this PR fixes

#31 

## Describe testing done for PR

```bash
homebrew-tanzu $ brew install --formula tanzu-community-edition.rb 
Running `brew update --preinstall`...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 5 formulae.
==> Deleted Formulae
szip

==> Downloading https://github.com/vmware-tanzu/community-edition/releases/download/v0.12.0-rc.2/tce-darwin-amd64-v0.12.0-rc.2
Already downloaded: /Users/karuppiahn/Library/Caches/Homebrew/downloads/e8c049ec7839db84167e409e9eea25c5d3157942cdd985ceb840824000ff2dc8--tce-darwin-amd64-v0.12.0-rc.2.tar.gz
==> Thanks for installing Tanzu Community Edition!
==> The Tanzu CLI has been installed on your system
==> 

==> ******************************************************************************
==> * To initialize all plugins required by Tanzu Community Edition, an additional
==> * step is required. To complete the installation, please run the following
==> * shell script:
==> *
==> * /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2/libexec/configure-tce.sh
==> *
==> ******************************************************************************
==> 

==> * To cleanup and remove Tanzu Community Edition from your system, run the
==> * following script:
==> /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2/libexec/uninstall.sh
==> 

🍺  /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2: 31 files, 1GB, built in 7 seconds
==> Running `brew cleanup tanzu-community-edition`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
homebrew-tanzu $ /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2/libexec/configure-tce.sh
MY_DIR: /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2/libexec
/Users/karuppiahn/Library/Application Support
Removing old plugin cache from /Users/karuppiahn/.cache/tanzu/catalog.yaml
Checking for required plugins...
Installing plugin 'apps:v0.6.0'
Installing plugin 'builder:v0.11.4'
Installing plugin 'cluster:v0.11.4'
Installing plugin 'codegen:v0.11.4'
Installing plugin 'conformance:v0.12.0-rc.2'
Installing plugin 'diagnostics:v0.12.0-rc.2'
Installing plugin 'kubernetes-release:v0.11.4'
Installing plugin 'login:v0.11.4'
Installing plugin 'management-cluster:v0.11.4'
Installing plugin 'package:v0.11.4'
Installing plugin 'pinniped-auth:v0.11.4'
Installing plugin 'secret:v0.11.4'
Installing plugin 'unmanaged-cluster:v0.12.0-rc.2'
Successfully installed all required plugins
✔  successfully initialized CLI 
Making a backup of your Kubernetes config files into /tmp

homebrew-tanzu $ 
homebrew-tanzu $ /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2/libexec/
homebrew-tanzu $ tanzu version
version: v0.11.4
buildDate: 2022-04-16
sha: a9b8f3a
homebrew-tanzu $ tanzu plugin list
  NAME                DESCRIPTION                                                        SCOPE       DISCOVERY      VERSION       STATUS     
  apps                Applications on Kubernetes                                         Standalone  default-local  v0.6.0        installed  
  builder             Build Tanzu components                                             Standalone  default-local  v0.11.4       installed  
  cluster             Kubernetes cluster operations                                      Standalone  default-local  v0.11.4       installed  
  codegen             Tanzu code generation tool                                         Standalone  default-local  v0.11.4       installed  
  conformance         Run Sonobuoy conformance tests against clusters                    Standalone  default-local  v0.12.0-rc.2  installed  
  diagnostics         Cluster diagnostics                                                Standalone  default-local  v0.12.0-rc.2  installed  
  kubernetes-release  Kubernetes release operations                                      Standalone  default-local  v0.11.4       installed  
  login               Login to the platform                                              Standalone  default-local  v0.11.4       installed  
  management-cluster  Kubernetes management cluster operations                           Standalone  default-local  v0.11.4       installed  
  package             Tanzu package management                                           Standalone  default-local  v0.11.4       installed  
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  Standalone  default-local  v0.11.4       installed  
  secret              Tanzu secret management                                            Standalone  default-local  v0.11.4       installed  
  unmanaged-cluster   Deploy and manage single-node, static, Tanzu clusters.             Standalone  default-local  v0.12.0-rc.2  installed  
homebrew-tanzu $ /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2/libexec/uninstall.sh
/Users/karuppiahn/Library/Application Support
Cleanup complete!

Removing the Tanzu CLI...

Uninstalling /usr/local/Cellar/tanzu-community-edition/v0.12.0-rc.2... (31 files, 1GB)
homebrew-tanzu $ tanzu
-bash: /usr/local/bin/tanzu: No such file or directory
homebrew-tanzu $ 
```


## Special notes for your reviewer

This also updates the formula with `v0.12.0-rc.2` as an example. We can merge this once `v0.12.0` is released. I could mark this ready then