### PR TITLE
Add formula for tanzu-cli version 0.90.0-alpha.0

### DIFF
--- a/tanzu-cli.rb
+++ b/tanzu-cli.rb
@@ -8,8 +8,8 @@ class TanzuCli < Formula
   head "https://github.com/vmware-tanzu/tanzu-cli.git", branch: "main"
 
   checksums = {
-    "darwin-amd64" => "91e499b6b8517879c14eabbca701fadc6a89bba49421aecd358028f04e536736",
-    "linux-amd64"  => "c9967ea224a9b2cb0edd9a061a157e234b83ed4876757b1eada0f3025214e4b6",
+    "darwin-amd64" => "cc9eb7c42ee4509abd08fbbfdc8dc80199c0d1c9b9b4dd400cd390dc448bd094",
+    "linux-amd64"  => "cd2f5116a905788c8a02845b999cf124b97a53d8aeef83f6ab0f8f95b6c7935a",
   }
 
   # Switch this to "arm64" when it is supported by CLI builds

--- a/tanzu-cli.rb
+++ b/tanzu-cli.rb
@@ -1,0 +1,51 @@
+# Copyright 2023 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+class TanzuCli < Formula
+  desc "The core Tanzu command-line tool"
+  homepage "https://github.com/vmware-tanzu/tanzu-cli"
+  version "0.90.0-alpha.0"
+  head "https://github.com/vmware-tanzu/tanzu-cli.git", branch: "main"
+
+  checksums = {
+    "darwin-amd64" => "91e499b6b8517879c14eabbca701fadc6a89bba49421aecd358028f04e536736",
+    "linux-amd64"  => "c9967ea224a9b2cb0edd9a061a157e234b83ed4876757b1eada0f3025214e4b6",
+  }
+
+  # Switch this to "arm64" when it is supported by CLI builds
+  $arch = "amd64"
+  on_intel do
+    $arch = "amd64"
+  end
+
+  $os = "darwin"
+  on_linux do
+    $os = "linux"
+  end
+
+  url "https://github.com/marckhouzam/tanzu-cli/releases/download/v#{version}/tanzu-cli-#{$os}-#{$arch}.tar.gz"
+  sha256 checksums["#{$os}-#{$arch}"]
+
+  def install
+    # Intall the tanzu CLI
+    bin.install "tanzu-cli-#{$os}_#{$arch}" => "tanzu"
+
+    # Setup shell completion
+    output = Utils.safe_popen_read(bin/"tanzu", "completion", "bash")
+    (bash_completion/"tanzu").write output
+
+    output = Utils.safe_popen_read(bin/"tanzu", "completion", "zsh")
+    (zsh_completion/"_tanzu").write output
+
+    output = Utils.safe_popen_read(bin/"tanzu", "completion", "fish")
+    (fish_completion/"tanzu.fish").write output
+  end
+
+  # This verifies the installation
+  test do
+    assert_match "version: v#{version}", shell_output("#{bin}/tanzu version")
+
+    output = shell_output("#{bin}/tanzu config get")
+    assert_match "clientOptions", output
+  end
+end


### PR DESCRIPTION
## What this PR does / why we need it

Provides a brew install for the Tanzu CLI version 0.90.0-alpha.0


## Describe testing done for PR

I've created test releases in my fork https://github.com/marckhouzam/homebrew-tanzu
And installed the CLI using `brew install marckhouzam/tanzu/tanzu-cli`

```
$ which tanzu
tanzu not found

$ brew install marckhouzam/tanzu/tanzu-cli
==> Fetching marckhouzam/tanzu/tanzu-cli
==> Downloading https://github.com/marckhouzam/tanzu-cli/releases/download/v0.90.0-pre-alpha.0/tanzu-cli-darwin-amd64.tar.gz
Already downloaded: /Users/kmarc/Library/Caches/Homebrew/downloads/9784c2d0b25e5254ee93aba1455ea7881e7df9bf9e7259e162d9a5803dbce4fe--tanzu-cli-darwin-amd64.tar.gz
==> Installing tanzu-cli from marckhouzam/tanzu
==> Downloading https://formulae.brew.sh/api/cask.jws.json
######################################################################## 100.0%
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/tanzu-cli/0.90.0-pre-alpha.0: 6 files, 59.0MB, built in 6 seconds
==> Running `brew cleanup tanzu-cli`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Downloading https://formulae.brew.sh/api/formula.jws.json
######################################################################## 100.0%

$ which tanzu
/opt/homebrew/bin/tanzu

$ tanzu version
version: v0.90.0-pre-alpha.0
buildDate: 2023-03-23
sha: a2d376cff
```

## Special notes for your reviewer
This is a draft PR for the moment because:
1. there is no 0.90.0-alpha.0 release available yet
2. the sha must be updated in this PR once the asset of 0.90.0-alpha.0 is available