### PR TITLE
Add v1.0.0-rc.0 under tanzu-cli-unstable

### DIFF
--- a/tanzu-cli-unstable.rb
+++ b/tanzu-cli-unstable.rb
@@ -1,15 +1,15 @@
 # Copyright 2023 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-class TanzuCli < Formula
-  desc "The core Tanzu command-line tool"
+class TanzuCliUnstable < Formula
+  desc "The core Tanzu command-line tool (unstable builds)"
   homepage "https://github.com/vmware-tanzu/tanzu-cli"
-  version "0.90.1"
+  version "1.0.0-rc.0"
   head "https://github.com/vmware-tanzu/tanzu-cli.git", branch: "main"
 
   checksums = {
-    "darwin-amd64" => "124a976dd75a9b43a7050cfc2ffa9f090321a488213f23f21f47657c58b14788",
-    "linux-amd64"  => "fec9e268399443de94d1761678aa39be18b7b685dd34a4412933943647b9d0be",
+    "darwin-amd64" => "7186eb48249609738621cb1fb5b27f6ce4e788a0dac255899129fc446964ef94",
+    "linux-amd64"  => "3fde5c059117c188a771c20f64a7c1ecba146bcb5237888daf98e7c2ad689a74",
   }
 
   # Switch this to "arm64" when it is supported by CLI builds


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds the Tanzu CLI v1.0.0-rc.0 under `vmware-tanzu/tanzu/tanzu-cli-unstable`.
Using a new `tanzu-cli-unstable` formula will allow testers to install pre-releases using
`brew install vmware-tanzu/tanzu/tanzu-cli-unstable`
while keeping the official version the default one installed when doing `brew install vmware-tanzu/tanzu/tanzu-cli`

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: # N/A

## Describe testing done for PR

I pushed this PR (using a different pre-release version that was already released on github) and verified I could install both the `tanzu-cli` and `tanzu0cli-unstable` formulae with the correct version being selected.

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
